### PR TITLE
added timeout arg

### DIFF
--- a/lib/modules/exec_command.py
+++ b/lib/modules/exec_command.py
@@ -18,7 +18,7 @@ class EXEC_COMMAND():
     def __init__(self, iWbemLevel1Login, codec):
         self.iWbemLevel1Login = iWbemLevel1Login
         self.codec = codec
-
+        self.timeout = 5
         self.obfu = VBSObfuscator()
     
     def save_ToFile(self, hostname, content):
@@ -99,7 +99,7 @@ class EXEC_COMMAND():
             #tag = executer.ExecuteVBS(vbs_content=vbs, filer_Query=filer_Query, returnTag=True)
             
             # Wait 5 seconds for next step.
-            for i in range(5,0,-1):
+            for i in range(self.timeout,0,-1):
                 print(f"[+] Waiting {i}s for next step.", end="\r", flush=True)
                 time.sleep(1)
             
@@ -132,7 +132,7 @@ class EXEC_COMMAND():
             #tag = executer.ExecuteVBS(vbs_content=vbs, filer_Query=filer_Query, returnTag=True)
             
             # Wait 5 seconds for next step.
-            for i in range(5,0,-1):
+            for i in range(self.timeout,0,-1):
                 print(f"[+] Waiting {i}s for next step.", end="\r", flush=True)
                 time.sleep(1)
         else:
@@ -176,7 +176,7 @@ class EXEC_COMMAND():
         tag = executer.ExecuteVBS(vbs_content=vbs, returnTag=True)
         
         # Wait 5 seconds for next step.
-        for i in range(5,0,-1):
+        for i in range(self.timeout,0,-1):
             print(f"[+] Waiting {i}s for next step.", end="\r", flush=True)
             time.sleep(1)
 
@@ -196,7 +196,7 @@ class EXEC_COMMAND_SHELL(cmd.Cmd):
         self.save_fileName = str(int(time.time())) + ".txt"
         self.logging = False
         self.interval = 5
-        self.cwd = 'C:\Windows\System32'
+        self.cwd = 'C:\\Windows\\System32'
         self.prompt = "%s>" %self.cwd
         self.intro = '[!] Launching semi-interactive shell - Careful what you execute'
         self.history = []

--- a/lib/modules/filetransfer.py
+++ b/lib/modules/filetransfer.py
@@ -12,6 +12,7 @@ class filetransfer_Toolkit():
     def __init__(self, iWbemLevel1Login, dcom):
         self.iWbemLevel1Login = iWbemLevel1Login
         self.dcom = dcom
+        self.timeout = 5 # default timeout
     
     @staticmethod
     def checkError(banner, resp):
@@ -71,7 +72,7 @@ class filetransfer_Toolkit():
         tag = executer.ExecuteVBS(vbs_content=vbs, returnTag=True, iWbemServices=iWbemServices_Subscription)
         
         # Wait 5 seconds for windows decode file.
-        for i in range(5,0,-1):
+        for i in range(self.timeout,0,-1):
             print(f"[+] Waiting {i}s for next step.", end="\r", flush=True)
             time.sleep(1)
         print('\r\n')
@@ -105,7 +106,7 @@ class filetransfer_Toolkit():
         tag = executer.ExecuteVBS(vbs_content=vbs, returnTag=True, iWbemServices=iWbemServices_Subscription)
         
         # Wait 5 seconds for next step.
-        for i in range(5,0,-1):
+        for i in range(self.timeout,0,-1):
             print(f"[+] Waiting {i}s for next step.", end="\r", flush=True)
             time.sleep(1)
         

--- a/lib/modules/rid_hijack.py
+++ b/lib/modules/rid_hijack.py
@@ -14,6 +14,7 @@ class RID_Hijack_Toolkit():
     def __init__(self, iWbemLevel1Login, dcom):
         self.iWbemLevel1Login = iWbemLevel1Login
         self.dcom = dcom
+        self.timeout = 5
 
     def save_ToFile(self, hostname, rid, content):
         path = 'save/'+hostname
@@ -82,7 +83,7 @@ class RID_Hijack_Toolkit():
             vbs = vbs.replace("REPLACE_WITH_USER", currentUsers)
             tag = executer_vbs.ExecuteVBS(vbs_content=vbs, returnTag=True)
             
-            for i in range(5,0,-1):
+            for i in range(self.timeout,0,-1):
                 print(f"[+] Waiting {i}s for next step.", end="\r", flush=True)
                 time.sleep(1)
             

--- a/wmiexec-pro.py
+++ b/wmiexec-pro.py
@@ -70,6 +70,7 @@ class WMIEXEC:
                 if self.__options.shell == True:
                     try:
                         executer_Shell = EXEC_COMMAND_SHELL(iWbemLevel1Login, dcom, self.__options.codec, addr)
+                        executer_Shell.interval = self.__options.timeout
                         executer_Shell.cmdloop()
                     except  (Exception, KeyboardInterrupt) as e:
                         if logging.getLogger().level == logging.DEBUG:
@@ -80,6 +81,7 @@ class WMIEXEC:
                         sys.exit(1)
                 else:
                     executer_ExecCommand = EXEC_COMMAND(iWbemLevel1Login, self.__options.codec)
+                    executer_ExecCommand.timeout = self.__options.timeout
                     if all([self.__options.command]) and self.__options.silent == True:
                         executer_ExecCommand.exec_command_silent(command=self.__options.command, old=self.__options.old)
                     elif all([self.__options.command]) and self.__options.silent == False:
@@ -94,6 +96,7 @@ class WMIEXEC:
 
             if self.__options.module == "filetransfer":
                 executer_Transfer = filetransfer_Toolkit(iWbemLevel1Login, dcom)
+                executer_Transfer.timeout = self.__options.timeout
                 if all([self.__options.src_file and self.__options.dest_file]):
                     if self.__options.upload == True:
                         executer_Transfer.uploadFile(src_File=self.__options.src_file, dest_File=r'%s'%self.__options.dest_file)
@@ -175,6 +178,7 @@ class WMIEXEC:
             
             if self.__options.module == "rid-hijack":
                 RID_Hijack = RID_Hijack_Toolkit(iWbemLevel1Login, dcom)
+                RID_Hijack.timeout = self.__options.timeout
                 if self.__options.query == True:
                     RID_Hijack.query_user()
                 elif self.__options.action:
@@ -215,8 +219,8 @@ if __name__ == '__main__':
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-codec', default="gbk", action='store', help='Sets encoding used (codec) from the target\'s output (default '
-                                                       '"gbk"). If errors are detected, run chcp.com at the target, '
+    parser.add_argument('-timeout', default=5, type=int, action='store', help='Set the timeout for the connection')
+    parser.add_argument('-codec', default="gbk", action='store', help='Sets the encoding used (codec) from the target\'s output (default "gbk"). If errors are detected, run chcp.com at the target, '
                                                        'map the result with '
                                                        'https://docs.python.org/3/library/codecs.html#standard-encodings and then execute wmiexec.py '
                                                        'again with -codec and the corresponding codec ')


### PR DESCRIPTION
added timeout arg for exec_command, filetransfer, rid_hijack

## example usage
```
python wmiexec-pro.py -timeout 10 admin@localhost exec-command
python wmiexec-pro.py -timeout 10 admin@localhost filetransfer 
python wmiexec-pro.py -timeout 10 admin@localhost rid-hijack  
```

## help options
```


options:
  -h, --help            show this help message and exit
  -ts                   Adds timestamp to every logging output
  -debug                Turn DEBUG output ON
  -timeout TIMEOUT      Set the timeout for the connection
  -codec CODEC          Sets the encoding used (codec) from the target's output (default "gbk"). If errors are detected, run chcp.com at the target, map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute wmiexec.py again with
                        -codec and the corresponding codec
  -com-version MAJOR_VERSION:MINOR_VERSION
                        DCOM version, format is MAJOR_VERSION:MINOR_VERSION e.g. 5.7
```