### PR TITLE
Fix relative script imports

### DIFF
--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -1,0 +1,8 @@
+import sys
+import os
+
+def get_vbs_path(filename):
+    # The directory of the main file
+    main_dir = os.path.dirname(os.path.abspath(sys.modules['__main__'].__file__))
+
+    return os.path.join(main_dir, 'lib', 'vbscripts', filename)

--- a/lib/methods/classMethodEx.py
+++ b/lib/methods/classMethodEx.py
@@ -4,6 +4,7 @@ import sys
 from io import StringIO
 from lib.methods.executeVBS import executeVBS_Toolkit
 from impacket.dcerpc.v5.dtypes import NULL
+from lib.helpers import get_vbs_path
 
 class class_MethodEx():
     def __init__(self, iWbemLevel1Login):
@@ -13,7 +14,7 @@ class class_MethodEx():
     # So lets we jump in vbs :)
     # Prepare for download file
     def create_Class(self, ClassName, iWbemServices_Cimv2=None, iWbemServices_Subscription=None, return_iWbemServices=False):
-        with open('./lib/vbscripts/CreateClass.vbs') as f: vbs = f.read()
+        with open(get_vbs_path('CreateClass.vbs')) as f: vbs = f.read()
         vbs = vbs.replace('REPLACE_WITH_CLASSNAME',ClassName)
 
         print("[+] Creating class: %s"%ClassName)

--- a/lib/modules/eventlog_fucker.py
+++ b/lib/modules/eventlog_fucker.py
@@ -1,5 +1,6 @@
 from lib.methods.executeVBS import executeVBS_Toolkit
 from impacket.dcerpc.v5.dtypes import NULL
+from lib.helpers import get_vbs_path
 
 class eventlog_Toolkit():
     def __init__(self, iWbemLevel1Login):
@@ -7,7 +8,7 @@ class eventlog_Toolkit():
 
     def fuck_EventLog(self):
         executer = executeVBS_Toolkit(self.iWbemLevel1Login)
-        tag = executer.ExecuteVBS(vbs_file='lib/vbscripts/ClearEventlog.vbs', returnTag=True)
+        tag = executer.ExecuteVBS(vbs_file=get_vbs_path('ClearEventlog.vbs'), returnTag=True)
         print("[+] Keepping note of this tag if you want to stop it: %s"%tag)
     
     def retrieve_EventLog(self, tag):

--- a/lib/modules/exec_command.py
+++ b/lib/modules/exec_command.py
@@ -13,6 +13,7 @@ from lib.methods.classMethodEx import class_MethodEx
 from lib.methods.executeVBS import executeVBS_Toolkit
 from lib.methods.Obfuscator import VBSObfuscator
 from impacket.dcerpc.v5.dtypes import NULL
+from lib.helpers import get_vbs_path
 
 class EXEC_COMMAND():
     def __init__(self, iWbemLevel1Login, codec):
@@ -90,7 +91,7 @@ class EXEC_COMMAND():
             
             print("[+] Executing command...(Sometime it will take a long time, please wait)")
 
-            with open('./lib/vbscripts/Exec-Command-Silent.vbs') as f: vbs = f.read()
+            with open(get_vbs_path('Exec-Command-Silent.vbs')) as f: vbs = f.read()
             vbs = vbs.replace('REPLACE_WITH_COMMAND', base64.b64encode(command.encode('utf-8')).decode('utf-8')).replace('REPLACE_WITH_TASK',random_TaskName)
             
             # Experimental: use timer instead of filter query
@@ -125,7 +126,7 @@ class EXEC_COMMAND():
         print("[+] Executing command...(Sometime it will take a long time, please wait)")
         if old == False:
             # Experimental: use timer instead of filter query
-            with open('./lib/vbscripts/Exec-Command-WithOutput.vbs') as f: vbs = f.read()
+            with open(get_vbs_path('Exec-Command-WithOutput.vbs')) as f: vbs = f.read()
             vbs = vbs.replace('REPLACE_WITH_COMMAND', base64.b64encode(command.encode('utf-8')).decode('utf-8')).replace('REPLACE_WITH_FILENAME', FileName).replace('REPLACE_WITH_CLASSNAME',ClassName_StoreOutput).replace('RELEACE_WITH_UUID',CMD_instanceID).replace('REPLACE_WITH_TASK',random_TaskName)
             tag = executer.ExecuteVBS(vbs_content=self.obfu.generator(vbs), returnTag=True)
             #filer_Query = r"SELECT * FROM __InstanceModificationEvent WITHIN 1 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System'"
@@ -137,7 +138,7 @@ class EXEC_COMMAND():
                 time.sleep(1)
         else:
             # Experimental: use timer instead of filter query
-            with open('./lib/vbscripts/Exec-Command-WithOutput-UnderNT6.vbs') as f: vbs = f.read()
+            with open(get_vbs_path('Exec-Command-WithOutput-UnderNT6.vbs')) as f: vbs = f.read()
             vbs = vbs.replace('REPLACE_WITH_COMMAND', base64.b64encode(command.encode('utf-8')).decode('utf-8')).replace('REPLACE_WITH_FILENAME', FileName).replace('REPLACE_WITH_CLASSNAME',ClassName_StoreOutput).replace('RELEACE_WITH_UUID',CMD_instanceID)
             tag = executer.ExecuteVBS(vbs_content=vbs, returnTag=True)
             
@@ -172,7 +173,7 @@ class EXEC_COMMAND():
         executer = executeVBS_Toolkit(self.iWbemLevel1Login)
         class_Method = class_MethodEx(self.iWbemLevel1Login)
 
-        with open('./lib/vbscripts/RemoveTempFile.vbs') as f: vbs = f.read()
+        with open(get_vbs_path('RemoveTempFile.vbs')) as f: vbs = f.read()
         tag = executer.ExecuteVBS(vbs_content=vbs, returnTag=True)
         
         # Wait 5 seconds for next step.
@@ -252,7 +253,7 @@ class EXEC_COMMAND_SHELL(cmd.Cmd):
         self.interval = int(seconds)
 
     def do_lognuke(self, line):
-        self.executer.ExecuteVBS(vbs_file='lib/vbscripts/ClearEventlog.vbs', iWbemServices=self.iWbemServices_Reuse_subscription)
+        self.executer.ExecuteVBS(vbs_file=get_vbs_path('ClearEventlog.vbs'), iWbemServices=self.iWbemServices_Reuse_subscription)
         print("[+] Nuke is landing.")
         print("[+] Log cleaning will never stop before use '-deep-clean' in 'execute-vbs' module")
 
@@ -316,7 +317,7 @@ class EXEC_COMMAND_SHELL(cmd.Cmd):
         command = line
         if "'" in command: command = command.replace("'",r'"')
 
-        with open('./lib/vbscripts/Exec-Command-WithOutput-Shell.vbs') as f: vbs = f.read()
+        with open(get_vbs_path('Exec-Command-WithOutput-Shell.vbs')) as f: vbs = f.read()
         vbs = vbs.replace('REPLACE_WITH_CWD', base64.b64encode(self.cwd.encode('utf-8')).decode('utf-8')).replace('REPLACE_WITH_COMMAND', base64.b64encode(command.encode('utf-8')).decode('utf-8')).replace('REPLACE_WITH_FILENAME', FileName).replace('REPLACE_WITH_CLASSNAME', self.ClassName_StoreOutput).replace('RELEACE_WITH_UUID',CMD_instanceID).replace('REPLACE_WITH_TASK',random_TaskName)
         # Reuse subscription namespace to avoid dcom limition
         

--- a/lib/modules/filetransfer.py
+++ b/lib/modules/filetransfer.py
@@ -7,6 +7,7 @@ import uuid
 from lib.methods.classMethodEx import class_MethodEx
 from lib.methods.executeVBS import executeVBS_Toolkit
 from impacket.dcerpc.v5.dtypes import NULL
+from lib.helpers import get_vbs_path
 
 class filetransfer_Toolkit():
     def __init__(self, iWbemLevel1Login, dcom):
@@ -63,7 +64,7 @@ class filetransfer_Toolkit():
         with open(src_File,'rb') as f: binary = f.read()
         binary_EncodeData = base64.b64encode(binary).decode('ascii')
         
-        with open('./lib/vbscripts/WriteFile.vbs') as f: vbs = f.read()
+        with open(get_vbs_path('WriteFile.vbs')) as f: vbs = f.read()
         vbs = vbs.replace('REPLACE_WITH_DEST', base64.b64encode(dest_File.encode('utf-8')).decode('utf-8')).replace('REPLACE_WITH_DATA', binary_EncodeData)
         executer = executeVBS_Toolkit(self.iWbemLevel1Login)
         print("[+] File uploading...")
@@ -100,7 +101,7 @@ class filetransfer_Toolkit():
         # Load target file into class
         print("[+] Converting file to base64 string and load it into wmi class.")
         Data_InstanceID = str(uuid.uuid4())
-        with open('./lib/vbscripts/LocalFileIntoClass.vbs') as f: vbs = f.read()
+        with open(get_vbs_path('LocalFileIntoClass.vbs')) as f: vbs = f.read()
         vbs = vbs.replace('REPLACE_WITH_TARGET_FILE', base64.b64encode(target_File.encode('utf-8')).decode('utf-8')).replace('RELEACE_WITH_UUID', Data_InstanceID).replace('REPLACE_WITH_CLASSNAME', ClassName_ForDownload)
         executer = executeVBS_Toolkit(self.iWbemLevel1Login)
         tag = executer.ExecuteVBS(vbs_content=vbs, returnTag=True, iWbemServices=iWbemServices_Subscription)

--- a/lib/modules/rid_hijack.py
+++ b/lib/modules/rid_hijack.py
@@ -9,6 +9,7 @@ import os
 from lib.methods.executeVBS import executeVBS_Toolkit
 from lib.modules.exec_command import EXEC_COMMAND
 from impacket.dcerpc.v5.dtypes import NULL
+from lib.helpers import get_vbs_path
 
 class RID_Hijack_Toolkit():
     def __init__(self, iWbemLevel1Login, dcom):
@@ -72,14 +73,14 @@ class RID_Hijack_Toolkit():
             ini_Content = ""
             for i in regini_Attr: ini_Content += i + "\r\n"
             ini_FileName = "windows-object-%s.ini"%str(uuid.uuid4())
-            with open('./lib/vbscripts/Exec-Command-Silent-UnderNT6-II.vbs') as f: vbs = f.read()
+            with open(get_vbs_path('Exec-Command-Silent-UnderNT6-II.vbs')) as f: vbs = f.read()
             vbs = vbs.replace("REPLACE_WITH_DEST", r'C:\windows\temp\%s'%ini_FileName).replace("REPLACE_WITH_DATA", base64.b64encode(ini_Content.encode('utf-8')).decode('utf-8')).replace("REPLACE_WITH_COMMAND", r'regini.exe C:\windows\temp\%s'%ini_FileName)
             tag = executer_vbs.ExecuteVBS(vbs_content=vbs, returnTag=True)
             exec_command.timer_For_UnderNT6()
             executer_vbs.remove_Event(tag)
         else:
             print("[+] Grant / Restrict user permissions to registry key via vbscript")
-            with open('./lib/vbscripts/GrantSamAccessPermission.vbs') as f: vbs = f.read()
+            with open(get_vbs_path('GrantSamAccessPermission.vbs')) as f: vbs = f.read()
             vbs = vbs.replace("REPLACE_WITH_USER", currentUsers)
             tag = executer_vbs.ExecuteVBS(vbs_content=vbs, returnTag=True)
             

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+impacket
+numpy


### PR DESCRIPTION
Scripts are imported using relative paths. They should be relative to the code main and not the current working directory. Otherwise packaging is hard.