### PR TITLE
fix(argparse): remove duplicate -dump argument in hashdump module

### DIFF
--- a/wmiexec-pro.py
+++ b/wmiexec-pro.py
@@ -311,10 +311,9 @@ if __name__ == "__main__":
     rid_HijackParser.add_argument("-restore", action="store", help="Restore user profile after you want to do evil operation, need to specify the backup json file)")
 
     # hashdump.py
-    hashdump_parser = subparsers.add_parser("hashdump", help="Loopping cleanning eventlog.")
-    hashdump_parser.add_argument("-dump", action="store", choices=["sss", "ntds"], 
-                                 help="Action you want to do.")
-    hashdump_parser.add_argument("-dump", action="store", choices=["sss", "ntds"], default="sss", help="Hash type you want to dump")
+    hashdump_parser = subparsers.add_parser("hashdump", help="Dump password hashes from the target system.")
+    hashdump_parser.add_argument("-dump", action="store", choices=["sss", "ntds"], default="sss",
+                               help="Hash type to dump (sss for Security Account Manager, ntds for NTDS.dit)")
 
     if len(sys.argv) == 1:
         parser.print_help()


### PR DESCRIPTION
## Description
Resolved an `ArgumentError` in the hashdump module caused by a duplicate `-dump` argument definition. The duplicate argument was removed, and the help text was enhanced for better clarity.

<img width="1285" height="501" alt="image" src="https://github.com/user-attachments/assets/453fbc43-e87f-401a-bcd0-c775696a830c" />


## Changes
- Removed the duplicate `-dump` argument from the hashdump module's argument parser
- Improved help text to better describe the hash dump functionality
- Updated the module's help text to be more descriptive

## Testing
- Verified that the `hashdump` module works with both `-dump sss` and `-dump ntds` options
- Confirmed that help text is displayed correctly